### PR TITLE
Use optparse like fypp in fypp_preprocessor.

### DIFF
--- a/tools/waf/fypp_preprocessor.py
+++ b/tools/waf/fypp_preprocessor.py
@@ -100,7 +100,6 @@ class fypp_preprocessor(Task.Task):
                 return 'Preprocessing'
         
 	def run(self):
-                opts = fypp.FyppOptions()
                 argparser = fypp.get_option_parser()
                 args = [FYPP_LINENUM_FLAG]
                 args += self.env.FYPP_FLAGS
@@ -108,7 +107,7 @@ class fypp_preprocessor(Task.Task):
 		args += [FYPP_INCPATH_ST % ss for ss in self.env['INCLUDES']]
                 args += [FYPP_INIFILES_ST % ss for ss in self.env['INIFILES']]
                 args += [FYPP_MODULES_ST % ss for ss in self.env['MODULES']]
-                opts = argparser.parse_args(args, namespace=opts)
+                opts, leftover = argparser.parse_args(args)
                 infile = self.inputs[0].abspath()
                 outfile = self.outputs[0].abspath()
                 if Logs.verbose:


### PR DESCRIPTION
The fypp_preprocessor.py module for waf seems to assume that fypp uses an argparse object, while in fact it uses optparse instead. I always get an error complaining about an unknown namespace argument because of this. This patch harmonizes the fypp_preprocessor module with fypp itself by using the optparse logic.

Probably it would be better to switch completely to argparse instead, as optparse is deprecated.