### PR TITLE
drop python2 and python <3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/bin/fypp
+++ b/bin/fypp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 ################################################################################
 #
@@ -51,7 +51,6 @@ subclasses of `FyppError`_ is raised:
   (by a stop- or an assert-directive).
 '''
 
-from __future__ import print_function
 import sys
 import types
 import inspect
@@ -61,10 +60,7 @@ import errno
 import time
 import optparse
 import io
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 
 # Prevent cluttering user directory with Python bytecode
 sys.dont_write_bytecode = True
@@ -1624,7 +1620,7 @@ class Renderer:
                 raise FyppFatalError(msg, fname, spans[0], exc)
             self._evaluator.closescope()
             try:
-                args, defaults, varpos, varkw = _GET_CALLABLE_ARGSPEC(func)
+                args, defaults, varpos, varkw = _get_callable_argspec(func)
             except Exception as exc:
                 msg = "invalid argument expression '{0}'".format(argexpr)
                 raise FyppFatalError(msg, fname, spans[0], exc)
@@ -2168,10 +2164,6 @@ class Evaluator:
     @classmethod
     def _get_restricted_builtins(cls):
         bidict = dict(cls._RESTRICTED_BUILTINS)
-        major = sys.version_info[0]
-        if major == 2:
-            bidict['True'] = True
-            bidict['False'] = False
         return bidict
 
 
@@ -2904,26 +2896,8 @@ def _open_output_file(outfile, encoding=None, create_parents=False):
     return outfp
 
 
-def _get_callable_argspec_py2(func):
-    argspec = inspect.getargspec(func)
-    varpos = argspec.varargs
-    varkw = argspec.keywords
-    args = argspec.args
-    tuplearg = False
-    for elem in args:
-        tuplearg = tuplearg or isinstance(elem, list)
-    if tuplearg:
-        msg = 'tuple argument(s) found'
-        raise FyppFatalError(msg)
-    defaults = {}
-    if argspec.defaults is not None:
-        for ind, default in enumerate(argspec.defaults):
-            iarg = len(args) - len(argspec.defaults) + ind
-            defaults[args[iarg]] = default
-    return args, defaults, varpos, varkw
-
-
-def _get_callable_argspec_py3(func):
+# Signature objects are available from Python 3.3 (and deprecated from 3.5)
+def _get_callable_argspec(func):
     sig = inspect.signature(func)
     args = []
     defaults = {}
@@ -2943,13 +2917,6 @@ def _get_callable_argspec_py3(func):
             raise FyppFatalError(msg)
     return args, defaults, varpos, varkw
 
-
-# Signature objects are available from Python 3.3 (and deprecated from 3.5)
-
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 3:
-    _GET_CALLABLE_ARGSPEC = _get_callable_argspec_py3
-else:
-    _GET_CALLABLE_ARGSPEC = _get_callable_argspec_py2
 
 
 def _blank_match(match):

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,7 @@ setup(
 
         'License :: OSI Approved :: BSD License',
 
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.0',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test/test_fypp.py
+++ b/test/test_fypp.py
@@ -47,18 +47,6 @@ _NEW_FILE = 1
 _RETURN_TO_FILE = 2
 
 
-# Some test flags, only to be used for exception tests, as the exception
-# stack could be different based on the python version
-
-_PYTHON_2 = 1
-
-_PYTHON_3 = 2
-
-_PYTHON_32_OR_BELOW = 3
-
-_PYTHON_33_OR_ABOVE = 4
-
-
 # Various basic tests
 #
 # Each test consists of a tuple containing the test name and a tuple with the
@@ -2580,20 +2568,11 @@ EXCEPTION_TESTS = [
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
      )
     ),
-    ('tuple_macro_argument_py2',
-     ([],
-      '#:def alma((x, y))\n#:enddef\n',
-      [(fypp.FyppFatalError, fypp.STRING, (0, 1)),
-       (fypp.FyppFatalError, None, None)],
-     ),
-     _PYTHON_2
-    ),
-    ('tuple_macro_argument_py3',
+    ('tuple_macro_argument',
      ([],
       '#:def alma((x, y))\n#:enddef\n',
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))],
      ),
-     _PYTHON_3
     ),
     ('repeated_keyword_argument',
      ([],
@@ -2615,20 +2594,12 @@ EXCEPTION_TESTS = [
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
      )
     ),
-    ('macrodef_pos_arg_after_var_arg_py2_py32',
-     ([],
-      '#:def mymacro(A, *B, C)\n#:enddef\n',
-      [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
-     ),
-     _PYTHON_32_OR_BELOW
-    ),
-    ('macrodef_pos_arg_after_var_arg_py33',
+    ('macrodef_pos_arg_after_var_arg',
      ([],
       '#:def mymacro(A, *B, C)\n#:enddef\n',
       [(fypp.FyppFatalError, fypp.STRING, (0, 1)),
        (fypp.FyppFatalError, None, None)]
      ),
-     _PYTHON_33_OR_ABOVE
     ),
     ('macrodef_pos_arg_after_var_kwarg',
      ([],
@@ -2969,18 +2940,7 @@ def _get_test_exception_method(args, inp, exceptions):
 
 
 def _test_needed(flag):
-    if flag == _PYTHON_2:
-        return sys.version_info[0] == 2
-    elif flag == _PYTHON_3:
-        return sys.version_info[0] == 3
-    elif flag == _PYTHON_32_OR_BELOW:
-        return (sys.version_info[0] == 2
-                or (sys.version_info[0] == 3 and sys.version_info[1] <= 2))
-    elif flag == _PYTHON_33_OR_ABOVE:
-        return (sys.version_info[0] == 3 and sys.version_info[1] >= 3)
-    else:
-        msg = 'invalid test flag ' + str(flag)
-        raise ValueError(msg)
+    return True
 
 
 class _TestContainer(unittest.TestCase):

--- a/tools/waf/fypp_fortran.py
+++ b/tools/waf/fypp_fortran.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 # Bálint Aradi, 2016-2020
 
-'''Uses Fypp as Fortran preprocessor (.fpp -> .f90). Use this one (instead of 
+'''Uses Fypp as Fortran preprocessor (.fpp -> .f90). Use this one (instead of
 fypp_preprocessor) if you want to preprocess Fortran sources with Fypp.
 
 You typically trigger the preprocessing via the 'fypp' feature::
@@ -11,16 +11,16 @@ You typically trigger the preprocessing via the 'fypp' feature::
 		opt.load('compiler_c')
 		opt.load('compiler_fc')
 		opt.load('fypp_fortran')
-	
+
 	def configure(conf):
 		conf.load('compiler_c')
 		conf.load('compiler_fc')
 		conf.load('fypp_fortran')
-	
-	
+
+
 	def build(bld):
 		sources = bld.path.ant_glob('*.fpp')
-		
+
 		bld(
 			features='fypp fc fcprogram',
 			source=sources,
@@ -41,14 +41,14 @@ import fypp_preprocessor
 
 def configure(conf):
 	fypp_preprocessor.configure(conf)
-	
+
 
 ################################################################################
 # Build
 ################################################################################
 
 class fypp_fortran(fypp_preprocessor.fypp_preprocessor):
-		
+
 	ext_in = [ '.fpp' ]
 	ext_out = [ '.f90' ]
 

--- a/tools/waf/fypp_preprocessor.py
+++ b/tools/waf/fypp_preprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 # Bálint Aradi, 2016-2020
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py34, py35, py36, py37, py38, py39
 
 [testenv]
 skip_missing_interpreters =


### PR DESCRIPTION
Linux distributions (for example Ubuntu in 18.04) started to drop the `/usr/bin/python` to `/usr/bin/python2` symlink as the next step to deprecate Python 2, resulting in `not found` errors when running fypp as an executable. Hence it might be time to switch to Python 3. Since Python 3.2 was EOL'd much earlier than Python 2.7, it should be fairly safe to drop support for everything prior to Python 3.3.