### PR TITLE
Added *_factory arguments to Fypp ctor, to allow custom components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9"
 
 script: test/runtests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 
 python:
-    - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
-    
+
 script: test/runtests.sh

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Added
 Changed
 -------
 
+* Support for Python 2.7, 3.3 and 3.4 dropped, support for Python 3.9 added.
+
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Added
 
 * Emission of standard (#line pragma styled) line directives.
 
+* Factory method arguments in Fypp constructor: evaluator_factory, parser_factor,
+  builder_factory and renderer_factory.
+
 
 Changed
 -------

--- a/bin/fypp
+++ b/bin/fypp
@@ -51,7 +51,6 @@ subclasses of `FyppError`_ is raised:
   (by a stop- or an assert-directive).
 '''
 
-from __future__ import print_function
 import sys
 import types
 import inspect
@@ -62,10 +61,7 @@ import time
 import optparse
 import io
 import platform
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 
 # Prevent cluttering user directory with Python bytecode
 sys.dont_write_bytecode = True
@@ -1633,7 +1629,7 @@ class Renderer:
                 raise FyppFatalError(msg, fname, spans[0], exc)
             self._evaluator.closescope()
             try:
-                args, defaults, varpos, varkw = _GET_CALLABLE_ARGSPEC(func)
+                args, defaults, varpos, varkw = _get_callable_argspec(func)
             except Exception as exc:
                 msg = "invalid argument expression '{0}'".format(argexpr)
                 raise FyppFatalError(msg, fname, spans[0], exc)
@@ -2177,10 +2173,6 @@ class Evaluator:
     @classmethod
     def _get_restricted_builtins(cls):
         bidict = dict(cls._RESTRICTED_BUILTINS)
-        major = sys.version_info[0]
-        if major == 2:
-            bidict['True'] = True
-            bidict['False'] = False
         return bidict
 
 
@@ -2937,26 +2929,8 @@ def _open_output_file(outfile, encoding=None, create_parents=False):
     return outfp
 
 
-def _get_callable_argspec_py2(func):
-    argspec = inspect.getargspec(func)
-    varpos = argspec.varargs
-    varkw = argspec.keywords
-    args = argspec.args
-    tuplearg = False
-    for elem in args:
-        tuplearg = tuplearg or isinstance(elem, list)
-    if tuplearg:
-        msg = 'tuple argument(s) found'
-        raise FyppFatalError(msg)
-    defaults = {}
-    if argspec.defaults is not None:
-        for ind, default in enumerate(argspec.defaults):
-            iarg = len(args) - len(argspec.defaults) + ind
-            defaults[args[iarg]] = default
-    return args, defaults, varpos, varkw
-
-
-def _get_callable_argspec_py3(func):
+# Signature objects are available from Python 3.3 (and deprecated from 3.5)
+def _get_callable_argspec(func):
     sig = inspect.signature(func)
     args = []
     defaults = {}
@@ -2976,13 +2950,6 @@ def _get_callable_argspec_py3(func):
             raise FyppFatalError(msg)
     return args, defaults, varpos, varkw
 
-
-# Signature objects are available from Python 3.3 (and deprecated from 3.5)
-
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 3:
-    _GET_CALLABLE_ARGSPEC = _get_callable_argspec_py3
-else:
-    _GET_CALLABLE_ARGSPEC = _get_callable_argspec_py2
 
 
 def _blank_match(match):

--- a/bin/fypp
+++ b/bin/fypp
@@ -2778,27 +2778,33 @@ def get_option_parser():
     usage = '%prog [options] [INFILE] [OUTFILE]'
     parser = optparse.OptionParser(prog=fypp_name, description=fypp_desc,
                                    version=fypp_version, usage=usage)
+
     msg = 'define variable, value is interpreted as ' \
           'Python expression (e.g \'-DDEBUG=1\' sets DEBUG to the ' \
           'integer 1) or set to None if omitted'
     parser.add_option('-D', '--define', action='append', dest='defines',
                       metavar='VAR[=VALUE]', default=defs.defines, help=msg)
+
     msg = 'add directory to the search paths for include files'
     parser.add_option('-I', '--include', action='append', dest='includes',
                       metavar='INCDIR', default=defs.includes, help=msg)
+
     msg = 'import a python module at startup (import only trustworthy modules '\
           'as they have access to an **unrestricted** Python environment!)'
     parser.add_option('-m', '--module', action='append', dest='modules',
                       metavar='MOD', default=defs.modules, help=msg)
+
     msg = 'directory to be searched for user imported modules before '\
           'looking up standard locations in sys.path'
     parser.add_option('-M', '--module-dir', action='append',
                       dest='moduledirs', metavar='MODDIR',
                       default=defs.moduledirs, help=msg)
+
     msg = 'emit line numbering markers'
     parser.add_option('-n', '--line-numbering', action='store_true',
                       dest='line_numbering', default=defs.line_numbering,
                       help=msg)
+
     msg = 'line numbering mode, \'full\' (default): line numbering '\
           'markers generated whenever source and output lines are out '\
           'of sync, \'nocontlines\': line numbering markers omitted '\
@@ -2807,42 +2813,53 @@ def get_option_parser():
                       choices=['full', 'nocontlines'],
                       default=defs.line_numbering_mode,
                       dest='line_numbering_mode', help=msg)
-    msg = 'line numbering marker format, \'cpp\' (default): GNU cpp format, '\
-          '\'gfortran5\': modified markers to work around bug in GFortran 5 '\
-          'and above'
+
+    msg = 'line numbering marker format,  currently \'std\', \'cpp\' and '\
+          '\'gfortran5\' are supported, where \'std\' emits #line pragmas '\
+          'similar to standard tools, \'cpp\' produces line directives as '\
+          'emitted by GNU cpp, and \'gfortran5\' cpp line directives with a '\
+          'workaround for a bug introduced in GFortran 5. Default: \'cpp\'.'
     parser.add_option('--line-marker-format', metavar='FMT',
                       choices=['cpp', 'gfortran5', 'std'],
                       dest='line_marker_format',
                       default=defs.line_marker_format, help=msg)
+
     msg = 'maximal line length (default: 132), lines modified by the '\
           'preprocessor are folded if becoming longer'
     parser.add_option('-l', '--line-length', type=int, metavar='LEN',
                       dest='line_length', default=defs.line_length, help=msg)
+
     msg = 'line folding mode, \'smart\' (default): indentation context '\
           'and whitespace aware, \'simple\': indentation context aware, '\
           '\'brute\': mechnical folding'
     parser.add_option('-f', '--folding-mode', metavar='MODE',
                       choices=['smart', 'simple', 'brute'], dest='folding_mode',
                       default=defs.folding_mode, help=msg)
+
     msg = 'suppress line folding'
     parser.add_option('-F', '--no-folding', action='store_true',
                       dest='no_folding', default=defs.no_folding, help=msg)
+
     msg = 'indentation to use for continuation lines (default 4)'
     parser.add_option('--indentation', type=int, metavar='IND',
                       dest='indentation', default=defs.indentation, help=msg)
+
     msg = 'produce fixed format output (any settings for options '\
           '--line-length, --folding-method and --indentation are ignored)'
     parser.add_option('--fixed-format', action='store_true',
                       dest='fixed_format', default=defs.fixed_format, help=msg)
+
     msg = 'character encoding for reading/writing files. Default: \'utf-8\'. '\
           'Note: reading from stdin and writing to stdout is encoded '\
           'according to the current locale and is not affected by this setting.'
     parser.add_option('--encoding', metavar='ENC', default=defs.encoding,
                       help=msg)
+
     msg = 'create parent folders of the output file if they do not exist'
     parser.add_option('-p', '--create-parents', action='store_true',
                       dest='create_parent_folder',
                       default=defs.create_parent_folder, help=msg)
+
     return parser
 
 

--- a/bin/fypp
+++ b/bin/fypp
@@ -2457,20 +2457,48 @@ class Fypp:
         options, leftover = optparser.parse_args(args=args)
         tool = fypp.Fypp(options)
 
+    For even more fine-grained control over how Fypp works, you can pass in custom
+    factory methods that handle construction of the evaluator, parser, builder and
+    renderer components. These factory methods must have the same signature as the
+    corresponding component's constructor. As an example of using a builder that's
+    customized by subclassing:
+
+        class MyBuilder (fypp.Builder):
+            def __init__(self):
+               super().__init__()
+               ...additional initialization...
+
+        tool = fypp.Fypp(options, builder_factory=MyBuilder)
+
 
     Args:
         options (object): Object containing the settings for Fypp. You typically
             would pass a customized `FyppOptions`_ instance or an
             ``optparse.Values`` object as returned by the option parser. If not
             present, the default settings in `FyppOptions`_ are used.
+        evaluator_factory (function): Factory function that returns an Evaluator
+            object. Its call signature must match that of the Evaluator constructor.
+            If not present, Evaluator() is used.
+        parser_factory (function): Factory function that returns a Parser object.
+            Its call signature must match that of the Parser constructor. If not
+            present, Parser() is used.
+        builder_factory (function): Factory function that returns a Builder object.
+            Its call signature must match that of the Builder constructor. If not
+            present, Builder() is used.
+        renderer_factory (function): Factory function that returns a Renderer
+            object. Its call signature must match that of the Renderer constructor.
+            If not present, Renderer() is used.
     '''
 
-    def __init__(self, options=None, parser_factory=Parser, builder_factory=Builder, renderer_factory=Renderer):
+    def __init__(self, options=None, evaluator_factory=Evaluator, parser_factory=Parser, builder_factory=Builder, renderer_factory=Renderer):
         syspath = self._get_syspath_without_scriptdir()
         self._adjust_syspath(syspath)
         if options is None:
             options = FyppOptions()
-        evaluator = Evaluator()
+        if inspect.signature(evaluator_factory) == inspect.signature(Evaluator):
+            evaluator = evaluator_factory()
+        else:
+            raise FyppFatalError('evaluator_factory has incorrect signature')
         self._encoding = options.encoding
         if options.modules:
             self._import_modules(options.modules, evaluator, syspath,

--- a/bin/fypp
+++ b/bin/fypp
@@ -2465,7 +2465,7 @@ class Fypp:
             present, the default settings in `FyppOptions`_ are used.
     '''
 
-    def __init__(self, options=None):
+    def __init__(self, options=None, parser_factory=Parser, builder_factory=Builder, renderer_factory=Renderer):
         syspath = self._get_syspath_without_scriptdir()
         self._adjust_syspath(syspath)
         if options is None:
@@ -2477,8 +2477,14 @@ class Fypp:
                                  options.moduledirs)
         if options.defines:
             self._apply_definitions(options.defines, evaluator)
-        parser = Parser(includedirs=options.includes, encoding=self._encoding)
-        builder = Builder()
+        if inspect.signature(parser_factory) == inspect.signature(Parser):
+            parser = parser_factory(includedirs=options.includes, encoding=self._encoding)
+        else:
+            raise FyppFatalError('parser_factory has incorrect signature')
+        if inspect.signature(builder_factory) == inspect.signature(Builder):
+            builder = builder_factory()
+        else:
+            raise FyppFatalError('builder_factory has incorrect signature')
 
         fixed_format = options.fixed_format
         linefolding = not options.no_folding
@@ -2495,9 +2501,12 @@ class Fypp:
         linenums = options.line_numbering
         contlinenums = (options.line_numbering_mode != 'nocontlines')
         self._create_parent_folder = options.create_parent_folder
-        renderer = Renderer(
-            evaluator, linenums=linenums, contlinenums=contlinenums,
-            linenumformat=options.line_marker_format, linefolder=linefolder)
+        if inspect.signature(renderer_factory) == inspect.signature(Renderer):
+            renderer = renderer_factory(
+                evaluator, linenums=linenums, contlinenums=contlinenums,
+                linenumformat=options.line_marker_format, linefolder=linefolder)
+        else:
+            raise FyppFatalError('renderer_factory has incorrect signature')
         self._preprocessor = Processor(parser, builder, renderer)
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,7 @@ setup(
 
         'License :: OSI Approved :: BSD License',
 
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.0',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     keywords='fortran metaprogramming pre-processor',

--- a/test/test_fypp.py
+++ b/test/test_fypp.py
@@ -51,18 +51,6 @@ _NEW_FILE = 1
 _RETURN_TO_FILE = 2
 
 
-# Some test flags, only to be used for exception tests, as the exception
-# stack could be different based on the python version
-
-_PYTHON_2 = 1
-
-_PYTHON_3 = 2
-
-_PYTHON_32_OR_BELOW = 3
-
-_PYTHON_33_OR_ABOVE = 4
-
-
 # Various basic tests
 #
 # Each test consists of a tuple containing the test name and a tuple with the
@@ -2603,20 +2591,11 @@ EXCEPTION_TESTS = [
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
      )
     ),
-    ('tuple_macro_argument_py2',
-     ([],
-      '#:def alma((x, y))\n#:enddef\n',
-      [(fypp.FyppFatalError, fypp.STRING, (0, 1)),
-       (fypp.FyppFatalError, None, None)],
-     ),
-     _PYTHON_2
-    ),
-    ('tuple_macro_argument_py3',
+    ('tuple_macro_argument',
      ([],
       '#:def alma((x, y))\n#:enddef\n',
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))],
      ),
-     _PYTHON_3
     ),
     ('repeated_keyword_argument',
      ([],
@@ -2638,20 +2617,12 @@ EXCEPTION_TESTS = [
       [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
      )
     ),
-    ('macrodef_pos_arg_after_var_arg_py2_py32',
-     ([],
-      '#:def mymacro(A, *B, C)\n#:enddef\n',
-      [(fypp.FyppFatalError, fypp.STRING, (0, 1))]
-     ),
-     _PYTHON_32_OR_BELOW
-    ),
-    ('macrodef_pos_arg_after_var_arg_py33',
+    ('macrodef_pos_arg_after_var_arg',
      ([],
       '#:def mymacro(A, *B, C)\n#:enddef\n',
       [(fypp.FyppFatalError, fypp.STRING, (0, 1)),
        (fypp.FyppFatalError, None, None)]
      ),
-     _PYTHON_33_OR_ABOVE
     ),
     ('macrodef_pos_arg_after_var_kwarg',
      ([],
@@ -2992,18 +2963,7 @@ def _get_test_exception_method(args, inp, exceptions):
 
 
 def _test_needed(flag):
-    if flag == _PYTHON_2:
-        return sys.version_info[0] == 2
-    elif flag == _PYTHON_3:
-        return sys.version_info[0] == 3
-    elif flag == _PYTHON_32_OR_BELOW:
-        return (sys.version_info[0] == 2
-                or (sys.version_info[0] == 3 and sys.version_info[1] <= 2))
-    elif flag == _PYTHON_33_OR_ABOVE:
-        return (sys.version_info[0] == 3 and sys.version_info[1] >= 3)
-    else:
-        msg = 'invalid test flag ' + str(flag)
-        raise ValueError(msg)
+    return True
 
 
 class _TestContainer(unittest.TestCase):

--- a/tools/waf/fypp_fortran.py
+++ b/tools/waf/fypp_fortran.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 # Bálint Aradi, 2016-2021
 

--- a/tools/waf/fypp_preprocessor.py
+++ b/tools/waf/fypp_preprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 # Bálint Aradi, 2016-2021
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py34, py35, py36, py37, py38, py39
 
 [testenv]
 skip_missing_interpreters =


### PR DESCRIPTION
These small changes allow customization of the parser, builder & renderer components -- in my particular case, to allow automated dependency generation to work. One possible weakness is the use of inspect.signature to check the signature of the factory methods -- not sure this will work for python < 3.3.
