### PR TITLE
Implement --define-mode and -S options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,9 +13,13 @@ Added
   interpreted: either as Python expressions (requiring proper quotation for
   strings) or as string literals (no quotation needed).
 
-* ``-S`` / ``--set`` option to define variables similarly to ``-D``, but with
-  values always evaluated as Python expressions (matching the behavior of the
-  ``#:set`` directive).
+* ``-S`` / ``--define-str`` option to define variables similarly to ``-D``, but
+  with values always treated as string literals independent of the settings in
+  the ``--define-mode`` option.
+
+* ``-E`` / ``--define-eval`` option to define variables similarly to ``-D``, but
+  with values always evaluated as Python expressions independent of the settings
+  in the ``--define-mode`` option.
 
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ Change Log
 Unreleased
 ==========
 
+Added
+-----
+
+* ``--define-mode`` option to control how values in ``-D`` options are
+  interpreted: either as Python expressions (requiring proper quotation for
+  strings) or as string literals (no quotation needed).
+
+* ``-S`` / ``--set`` option to define variables similarly to ``-D``, but with
+  values always evaluated as Python expressions (matching the behavior of the
+  ``#:set`` directive).
+
+
 Changed
 -------
 

--- a/docs/preprocessor-language.rst
+++ b/docs/preprocessor-language.rst
@@ -245,13 +245,53 @@ Following predefined functions are available:
 Initializing variables
 ----------------------
 
-Initial values for preprocessor variables can be set via the command line option
-(``-D``) at startup::
+Initial values for preprocessor variables can be set at startup using the
+command-line options ``-S`` (*set*) or ``-D`` (*define*). The value is evaluated
+as a Python expression, or set to ``None`` if omitted. For example::
+
+  fypp -SDEBUG=0 -SWITH_MPI
+
+initializes the variable ``DEBUG`` with the integer value ``0`` and ``WITH_MPI``
+with ``None`` (similar to the ``#:set`` preprocessor directive). The ``-D``
+option behaves similarly, and is commonly used in build systems to define
+preprocessor variables::
 
   fypp -DDEBUG=0 -DWITH_MPI
 
-The assigned value for a given variable is evaluated in Python. If no value is
-provided, `None` is assigned.
+By default, values provided via ``-D`` are also evaluated as Python expressions.
+This means that defining string literals requires explicit quotation. For
+example::
+
+  fypp -DMYSTR=Hello
+
+would attempt to assign the value of an existing variable ``Hello`` to
+``MYSTR``. To assign the string literal ``"Hello"`` instead, proper quoting is
+required::
+
+  fypp -DMYSTR="Hello"
+
+When invoking Fypp from environments that strip outer quotes (e.g., shells or
+build systems), this can become somewhat cumbersome, as quotes must be
+additionally escaped or nested::
+
+  fypp -DMYSTR='"Hello"'
+
+To simplify such cases, Fypp supports the option ``--define-mode`` to control
+how ``-D`` values are interpreted. This option accepts two values:
+
+- ``expr`` (default): interpret values as Python expressions
+- ``str``: treat all values as string literals
+
+For example::
+
+  fypp --define-mode=str -DMYSTR=Hello
+
+assigns the string literal ``"Hello"`` to ``MYSTR`` without requiring quotes. If
+no value is given, the default is the empty string ``""``.
+
+Note: The ``-S`` option is **not affected** by ``--define-mode``. Values set via
+``-S`` are always evaluated as Python expressions, with ``None`` as the default
+if the value is omitted.
 
 
 Importing modules at startup

--- a/src/fypp.py
+++ b/src/fypp.py
@@ -2508,11 +2508,13 @@ class Fypp:
         if options.modules:
             self._import_modules(options.modules, evaluator, syspath,
                                  options.moduledirs)
-        evaluate = options.define_mode == 'expr'
+        evaluate = options.define_mode == 'eval'
         if options.defines:
             self._apply_definitions(options.defines, evaluator, evaluate)
-        if options.sets:
-            self._apply_definitions(options.sets, evaluator, True)
+        if options.defines_str:
+            self._apply_definitions(options.defines_str, evaluator, False)
+        if options.defines_eval:
+            self._apply_definitions(options.defines_eval, evaluator, True)
         if inspect.signature(parser_factory) == inspect.signature(Parser):
             parser = parser_factory(includedirs=options.includes,
                                     encoding=self._encoding)
@@ -2676,9 +2678,10 @@ class FyppOptions(optparse.Values):
 
     def __init__(self):
         optparse.Values.__init__(self)
-        self.define_mode = 'expr'
         self.defines = []
-        self.sets = []
+        self.define_mode = 'eval'
+        self.defines_str = []
+        self.defines_eval = []
         self.includes = []
         self.line_numbering = False
         self.line_numbering_mode = 'full'
@@ -2833,22 +2836,27 @@ def get_option_parser():
                                    version=fypp_version, usage=usage)
 
     msg = 'define a variable; value interpreted depending on the '\
-          '--define-mode option, either as Python expression (e.g '\
+          '--define-mode option, either evaluated as a Python expression (e.g '\
           '\'-DDEBUG=1\' sets DEBUG to the integer 1) with None as default '\
           'value, or as string literal with the empty string as default value'
     parser.add_option('-D', '--define', action='append', dest='defines',
                       metavar='VAR[=VALUE]', default=defs.defines, help=msg)
 
-    msg = 'value evaluation mode in -D options, \'expr\': values are Python '\
+    msg = 'value evaluation mode in -D options, \'eval\': values are evaluated as Python '\
           'expressions (default, requires quotation for string values), '\
           '\'str\': values are string literals (no quotation needed)'
-    parser.add_option('--define-mode', metavar='MODE', choices=['expr', 'str'],
+    parser.add_option('--define-mode', metavar='MODE', choices=['eval', 'str'],
                       default=defs.define_mode, dest='define_mode', help=msg)
 
-    msg = 'set a variable; similar to the -D option, but the value is always '\
-          'evaluated as a Python expression with None as default value'
-    parser.add_option('-S', '--set', action='append', dest='sets',
-                      metavar='VAR[=VALUE]', default=defs.sets, help=msg)
+    msg = 'define a variable with a string literal value; similar to the -D option, but the value '\
+          'is always interpreted as a string literal with the empty string as default value'
+    parser.add_option('-S', '--define-str', action='append', dest='defines_str',
+                      metavar='VAR[=VALUE]', default=defs.defines_str, help=msg)
+
+    msg = 'define a variable with an evaluated expression; similar to the -D option, but the '\
+          'value is always evaluated as a Python expression with None as default value'
+    parser.add_option('-E', '--define-eval', action='append', dest='defines_eval',
+                      metavar='VAR[=VALUE]', default=defs.defines_eval, help=msg)
 
     msg = 'add directory to the search paths for include files'
     parser.add_option('-I', '--include', action='append', dest='includes',

--- a/test/test_fypp.py
+++ b/test/test_fypp.py
@@ -10,8 +10,20 @@ def _linenum(linenr, fname=None, flag=None):
         fname = fypp.STRING
     return fypp.linenumdir_cpp(linenr, fname, flag)
 
-def _defvar(var, val):
-    return '-D{0}={1}'.format(var, val)
+def _defvar(var, val=None):
+    if val is not None:
+        return '-D{0}={1}'.format(var, val)
+    else:
+        return '-D{0}'.format(var)
+
+def _def_mode(defmode):
+    return '--define-mode={0}'.format(defmode)
+
+def _setvar(var, val=None):
+    if val is not None:
+        return '-S{0}={1}'.format(var, val)
+    else:
+        return '-S{0}'.format(var)
 
 def _incdir(path):
     return '-I{0}'.format(path)
@@ -1715,6 +1727,85 @@ SIMPLE_TESTS = [
      ([_defvar("A", "'a=b'")],
       '${A}$',
       'a=b'
+     )
+    ),
+    ('define_mode_default_int',
+     ([_defvar("A", "12")],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 int'
+     )
+    ),
+    ('define_mode_default_str',
+     ([_defvar("A", "'12'")],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
+     )
+    ),
+    ('define_mode_default_none',
+     ([_defvar("A")],
+       '${A}$ ${A.__class__.__name__}$',
+       ' NoneType'
+     )
+    ),
+    ('define_mode_expr_int',
+     ([_defvar("A", "12"), _def_mode('expr')],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 int'
+     )
+    ),
+    ('define_mode_expr_str',
+     ([_defvar("A", "'12'"), _def_mode('expr')],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
+     )
+    ),
+    ('define_mode_expr_none',
+     ([_defvar("A"), _def_mode('expr')],
+       '${A}$ ${A.__class__.__name__}$',
+       ' NoneType'
+     )
+    ),
+    ('define_mode_str_int',
+     ([_defvar("A", "12"), _def_mode('str')],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
+     )
+    ),
+    ('define_mode_str_str',
+     ([_defvar("A", "'12'"), _def_mode('str')],
+       '${A}$ ${A.__class__.__name__}$',
+       '\'12\' str'
+     )
+    ),
+    ('define_mode_str_none',
+     ([_defvar("A"), _def_mode('str')],
+       '${A}$ ${A.__class__.__name__}$',
+       ' str'
+     )
+    ),
+    ('set_int',
+     ([_setvar("A", "12")],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 int'
+     )
+    ),
+    ('set_str',
+     ([_setvar("A", "'12'")],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
+     )
+    ),
+    ('set_none',
+     ([_setvar("A")],
+       '${A}$ ${A.__class__.__name__}$',
+       ' NoneType'
+     )
+    ),
+    # Check, whether evaluation in set is independent of the --define-mode option
+    ('set_int_defmode_str',
+     ([_setvar("A", "12"), _def_mode('str')],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 int'
      )
     ),
 ]

--- a/test/test_fypp.py
+++ b/test/test_fypp.py
@@ -11,19 +11,16 @@ def _linenum(linenr, fname=None, flag=None):
     return fypp.linenumdir_cpp(linenr, fname, flag)
 
 def _defvar(var, val=None):
-    if val is not None:
-        return '-D{0}={1}'.format(var, val)
-    else:
-        return '-D{0}'.format(var)
+    return '-D{0}={1}'.format(var, val) if val is not None else '-D{0}'.format(var)
 
 def _def_mode(defmode):
     return '--define-mode={0}'.format(defmode)
 
-def _setvar(var, val=None):
-    if val is not None:
-        return '-S{0}={1}'.format(var, val)
-    else:
-        return '-S{0}'.format(var)
+def _defvar_eval(var, val=None):
+    return '-E{0}={1}'.format(var, val) if val is not None else '-E{0}'.format(var)
+
+def _defvar_str(var, val=None):
+    return '-S{0}={1}'.format(var, val) if val is not None else '-S{0}'.format(var)
 
 def _incdir(path):
     return '-I{0}'.format(path)
@@ -1748,19 +1745,19 @@ SIMPLE_TESTS = [
      )
     ),
     ('define_mode_expr_int',
-     ([_defvar("A", "12"), _def_mode('expr')],
+     ([_defvar("A", "12"), _def_mode('eval')],
        '${A}$ ${A.__class__.__name__}$',
        '12 int'
      )
     ),
     ('define_mode_expr_str',
-     ([_defvar("A", "'12'"), _def_mode('expr')],
+     ([_defvar("A", "'12'"), _def_mode('eval')],
        '${A}$ ${A.__class__.__name__}$',
        '12 str'
      )
     ),
     ('define_mode_expr_none',
-     ([_defvar("A"), _def_mode('expr')],
+     ([_defvar("A"), _def_mode('eval')],
        '${A}$ ${A.__class__.__name__}$',
        ' NoneType'
      )
@@ -1783,29 +1780,54 @@ SIMPLE_TESTS = [
        ' str'
      )
     ),
-    ('set_int',
-     ([_setvar("A", "12")],
+    ('define_eval_int',
+     ([_defvar_eval("A", "12")],
        '${A}$ ${A.__class__.__name__}$',
        '12 int'
      )
     ),
-    ('set_str',
-     ([_setvar("A", "'12'")],
+    ('define_eval_str',
+     ([_defvar_eval("A", "'12'")],
        '${A}$ ${A.__class__.__name__}$',
        '12 str'
      )
     ),
-    ('set_none',
-     ([_setvar("A")],
+    ('define_eval_none',
+     ([_defvar_eval("A")],
        '${A}$ ${A.__class__.__name__}$',
        ' NoneType'
      )
     ),
-    # Check, whether evaluation in set is independent of the --define-mode option
-    ('set_int_defmode_str',
-     ([_setvar("A", "12"), _def_mode('str')],
+    ('define_str_int',
+     ([_defvar_str("A", "12")],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
+     )
+    ),
+    ('define_str_str',
+     ([_defvar_str("A", "'12'")],
+       '${A}$ ${A.__class__.__name__}$',
+       '\'12\' str'
+     )
+    ),
+    ('define_str_none',
+     ([_defvar_str("A")],
+       '${A}$ ${A.__class__.__name__}$',
+       ' str'
+     )
+    ),
+    # Check, whether value treatment is independent of the --define-mode option
+    ('define_eval_defmode_str',
+     ([_defvar_eval("A", "12"), _def_mode('str')],
        '${A}$ ${A.__class__.__name__}$',
        '12 int'
+     )
+    ),
+    # Check, whether value treatment is independent of the --define-mode option
+    ('define_str_defmode_eval',
+     ([_defvar_str("A", "12"), _def_mode('eval')],
+       '${A}$ ${A.__class__.__name__}$',
+       '12 str'
      )
     ),
 ]


### PR DESCRIPTION
The --define-mode option controls, whether values in -D options are evaluated or treated as string literals. The -S (set) option initializes variables with expression evaluation (independent of the --define-mode settings).

Closes #32 