### PR TITLE
Check Python version before importing pathlib

### DIFF
--- a/src/fypp.py
+++ b/src/fypp.py
@@ -50,8 +50,11 @@ subclasses of `FyppError`_ is raised:
 * FyppStopRequest: Stop was triggered by an explicit request in the input
   (by a stop- or an assert-directive).
 '''
-import pathlib
 import sys
+MIN_PYTHON = (3, 5)
+if sys.version_info < MIN_PYTHON:
+    sys.exit("Fypp requires Python %s.%s or later.\n" % MIN_PYTHON)
+import pathlib
 import types
 import inspect
 import re


### PR DESCRIPTION
As pathlib is only available after Python 3.5 and the documentation states this Python version is required...